### PR TITLE
Add workaround for Mac OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ First make sure you have:
 2. NodeJS with all the development headers (if using a package manager like apt-get, follow the instructions here: https://nodejs.org/en/download/package-manager/)
 3. python 2.7
 
+*On Mac OSX*
+```
+cd /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr
+sudo ln -s /usr/local local
+```
+
 Then install node-gyp system-wide:
 
 ```


### PR DESCRIPTION
Without this fix we see the following error:

```bash
$ npm install openvenues/node-postal
-
> node-postal@0.2.0 install /Users/diana/Code/api/node_modules/node-postal
> (node-gyp rebuild) || (exit 0)

child_process: customFds option is deprecated, use stdio instead.
  CXX(target) Release/obj.target/expand/src/expand.o
../src/expand.cc:1:10: fatal error: 'libpostal/libpostal.h' file not found
#include <libpostal/libpostal.h>
         ^
1 error generated.
make: *** [Release/obj.target/expand/src/expand.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.emit (events.js:110:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1067:12)
gyp ERR! System Darwin 15.2.0
gyp ERR! command "node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/diana/Code/api/node_modules/node-postal
gyp ERR! node -v v0.12.0
gyp ERR! node-gyp -v v1.0.2
gyp ERR! not ok
node-postal@0.2.0 node_modules/node-postal
├── bindings@1.2.1
└── nan@2.2.0
```