### PR TITLE
Update Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ branches:
     only:
         - master
 node_js:
-  - "7"
-  - "6"
-  - "5"
-  - "4"
-  - "0.12"
-  - "0.10"
+    - "12"
+    - "10"
+    - "8"
+matrix:
+    allow_failures:
+        - node_js: "12"
 addons:
     apt:
         sources:


### PR DESCRIPTION
Only Node.js 8, 10, and 12 are currently supported upstream. Older versions have reached EOL.

Node.js 12 tests appear to fail, but might be fixed by https://github.com/openvenues/node-postal/pull/21.

Until then Node.js 12 is listed as an `allowed_failure`