### PR TITLE
chore: update npm package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-postal",
-    "version": "1.0.0",
+    "version": "1.1.1",
     "author": "Al Barrentine (@thatdatabaseguy)",
     "description": "International address parsing/normalization at C speed",
     "main": "index.js",


### PR DESCRIPTION
One of the issues with https://github.com/openvenues/node-postal/issues/28 was that the `package.json` version number didn't change at the time of the commits.

I was able to modify it in the `npm publish` packages with `npm version` but the git history couldn't change without rebasing and I wasn't going to rebase and force push master 🤯

This PR fixes that by setting the version number in `package.json` to equal the latest published release on `npm`.