### PR TITLE
Add support for Node.js 16

### DIFF
--- a/src/expand.cc
+++ b/src/expand.cc
@@ -170,7 +170,12 @@ void init(v8::Local<v8::Object> exports) {
     exports->Set(context, Nan::New("ADDRESS_PO_BOX").ToLocalChecked(), Nan::New(LIBPOSTAL_ADDRESS_PO_BOX));
     exports->Set(context, Nan::New("ADDRESS_ALL").ToLocalChecked(), Nan::New(LIBPOSTAL_ADDRESS_ALL));
 
-    node::AtExit(cleanup);
+    #if NODE_MAJOR_VERSION >= 12
+        node::Environment* env = node::GetCurrentEnvironment(Nan::GetCurrentContext());
+        node::AtExit(env, cleanup, NULL);
+    #else
+        node::AtExit(cleanup);
+    #endif
 }
 
 NODE_MODULE(expand, init)

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -115,7 +115,12 @@ void init(v8::Local<v8::Object> exports) {
         Nan::New<v8::FunctionTemplate>(ParseAddress)->GetFunction(context).ToLocalChecked()
     );
 
-    node::AtExit(cleanup);
+    #if NODE_MAJOR_VERSION >= 12
+        node::Environment* env = node::GetCurrentEnvironment(Nan::GetCurrentContext());
+        node::AtExit(env, cleanup, NULL);
+    #else
+        node::AtExit(cleanup);
+    #endif
 }
 
 NODE_MODULE(parser, init)


### PR DESCRIPTION
`AtExit` with 1 parameter has been deprecated since Node 13, and [removed completely](https://github.com/nodejs/node/pull/30227) since Node 16 (the current LTS version). This pull request adds support for recent versions of Node.