### PR TITLE
fix: fixed error: ‘class v8::Object’ has no member named ‘CreationCon…

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,5 @@
 name: 'Continuous Integration'
-on: push
+on: [push, pull_request]
 jobs:
   unit-tests:
     runs-on: '${{ matrix.os }}'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,6 +13,8 @@ jobs:
           - 12.x
           - 14.x
           - 16.x
+          - 18.x
+          - 20.x
         include:
           - os: ubuntu-20.04
             node-version: 8.x

--- a/src/expand.cc
+++ b/src/expand.cc
@@ -133,7 +133,7 @@ static void cleanup(void*) {
 }
 
 void init(v8::Local<v8::Object> exports) {
-    v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();
+    v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked(); //required to work on node v16+
 
     if (!libpostal_setup() || !libpostal_setup_language_classifier()) {
         Nan::ThrowError("Could not load libpostal");

--- a/src/expand.cc
+++ b/src/expand.cc
@@ -133,8 +133,13 @@ static void cleanup(void*) {
 }
 
 void init(v8::Local<v8::Object> exports) {
-    v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked(); //required to work on node v16+
-
+    // Check Node.js version
+    #if NODE_MAJOR_VERSION >= 16
+        v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();    #else
+    #else
+        v8::Local<v8::Context> context = exports->CreationContext();
+    #endif
+    
     if (!libpostal_setup() || !libpostal_setup_language_classifier()) {
         Nan::ThrowError("Could not load libpostal");
         return;

--- a/src/expand.cc
+++ b/src/expand.cc
@@ -135,7 +135,7 @@ static void cleanup(void*) {
 void init(v8::Local<v8::Object> exports) {
     // Check Node.js version
     #if NODE_MAJOR_VERSION >= 16
-        v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();    #else
+        v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();
     #else
         v8::Local<v8::Context> context = exports->CreationContext();
     #endif

--- a/src/expand.cc
+++ b/src/expand.cc
@@ -133,7 +133,7 @@ static void cleanup(void*) {
 }
 
 void init(v8::Local<v8::Object> exports) {
-    v8::Local<v8::Context> context = exports->CreationContext();
+    v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();
 
     if (!libpostal_setup() || !libpostal_setup_language_classifier()) {
         Nan::ThrowError("Could not load libpostal");

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -96,7 +96,12 @@ static void cleanup(void*) {
 }
 
 void init(v8::Local<v8::Object> exports) {
-    v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();
+    // Check Node.js version
+    #if NODE_MAJOR_VERSION >= 16
+        v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();
+    #else
+        v8::Local<v8::Context> context = exports->CreationContext();
+    #endif
 
     if (!libpostal_setup() || !libpostal_setup_parser()) {
         Nan::ThrowError("Could not load libpostal");

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -96,7 +96,7 @@ static void cleanup(void*) {
 }
 
 void init(v8::Local<v8::Object> exports) {
-    v8::Local<v8::Context> context = exports->CreationContext();
+    v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();
 
     if (!libpostal_setup() || !libpostal_setup_parser()) {
         Nan::ThrowError("Could not load libpostal");

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -5,6 +5,7 @@
 
 void ParseAddress(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     v8::Isolate *isolate = info.GetIsolate();
+	v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
     if (info.Length() < 1) {
         Nan::ThrowTypeError(PARSER_USAGE);


### PR DESCRIPTION
…text’; allowing node-gyp to rebind with node-postal, which enables node-postal to be used on Node v20.5.0