### PR TITLE
Fixed runtime crash

### DIFF
--- a/src/expand.cc
+++ b/src/expand.cc
@@ -120,9 +120,10 @@ void ExpandAddress(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     for (i = 0; i < num_expansions; i++) {
         v8::Local<v8::String> e = Nan::New(expansions[i]).ToLocalChecked();
         ret->Set(context, i, e);
-        free(expansions[i]);
     }
-    free(expansions);
+
+    // Free expansions
+    libpostal_expansion_array_destroy(expansions, num_expansions);
 
     info.GetReturnValue().Set(ret);
 }


### PR DESCRIPTION
Instead of manually freeing the memory allocated by `libpostal_expand_address()`, use `libpostal_expansion_array_destroy()` to free the memory.

This is how example program from [libpostal](https://github.com/openvenues/libpostal?tab=readme-ov-file#usage-normalization) frees the memory. For more details, please refer to this issue:
https://github.com/openvenues/libpostal/issues/682